### PR TITLE
fix: append ts file extension to theme.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Your project should now be running and accessible on `http://localhost:3000`.
 
 You can customise the main theme in `styles/theme.css.ts`, and add custom css overrides in `styles/global.css`.
 
-For a simple color scheme change, you can change the color values in `styles/theme.css`.
+For a simple color scheme change, you can change the color values in `styles/theme.css.ts`.
 
 ```
 // Valid colour values are short and long hex codes (#00ff00) (#f00)


### PR DESCRIPTION
## Summary

Closes #6 

This updates `styles/theme.css`(a files that doesn't exist) to `styles/theme.css.ts` (which [exists](https://github.com/ourzora/mint-page-template/blob/main/styles/theme.css.ts)).

cc: @kolber for review 👓 
