### PR TITLE
Change Market Link to Opensea.

### DIFF
--- a/components/MintButton.tsx
+++ b/components/MintButton.tsx
@@ -86,13 +86,13 @@ export function MintButton({
         </Paragraph>
         <Button
           as="a"
-          href={`https://zora.co/collections/${collection.address}`}
+          href={`https://opensea.io/assets?search[query]=${collection.address}`}
           target="_blank"
           rel="noreferrer"
           size="lg"
           my="x3"
         >
-          View on Zora Marketplace
+          View on Opensea
         </Button>
       </Box>
     )


### PR DESCRIPTION
Same issue as here: 
https://github.com/ourzora/zora-co/pull/2206
https://linear.app/ourzora/issue/CREAT-1659/link-sold-out-collection-button-to-opensea-purchase-page